### PR TITLE
upgrade to spring boot 2.7.0 and graphglue 3.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,9 @@
 description = "A Cross-Component Issue Management System for Component-based Architectures"
 
 plugins {
-    id("org.springframework.boot") version "2.6.7"
-	id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    id("org.springframework.boot") version "2.7.0"
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
-    id("com.expediagroup.graphql") version "6.0.0-alpha.2"
 }
 
 repositories {
@@ -13,12 +11,6 @@ repositories {
 }
 
 dependencies {
-    implementation("io.github.graphglue", "graphglue", "2.0.0")
+    implementation("io.github.graphglue", "graphglue", "3.0.0")
     implementation("com.graphql-java","graphql-java-extended-scalars", "18.0")
-}
-
-graphql {
-    schema {
-        packages = listOf("gropius")
-    }
 }

--- a/src/main/kotlin/gropius/model/architecture/ComponentVersion.kt
+++ b/src/main/kotlin/gropius/model/architecture/ComponentVersion.kt
@@ -32,7 +32,7 @@ class ComponentVersion(
     @GraphQLDescription("The Component which defines this ComponentVersions")
     @FilterProperty
     @delegate:Transient
-    var component by NodeProperty<Component>()
+    val component by NodeProperty<Component>()
 
     @NodeRelationship(Interface.COMPONENT, Direction.INCOMING)
     @GraphQLDescription("Interfaces created by visible InterfaceSpecifications, can be used in Relations.")

--- a/src/main/kotlin/gropius/model/architecture/IMSProject.kt
+++ b/src/main/kotlin/gropius/model/architecture/IMSProject.kt
@@ -25,13 +25,13 @@ class IMSProject : ExtensibleNode() {
     @GraphQLDescription("The trackable which is synced.")
     @FilterProperty
     @delegate:Transient
-    var trackable by NodeProperty<Trackable>()
+    val trackable by NodeProperty<Trackable>()
 
     @NodeRelationship(IMS.PROJECT, Direction.INCOMING)
     @GraphQLDescription("The IMS this project is a part of.")
     @FilterProperty
     @delegate:Transient
-    var ims by NodeProperty<IMS>()
+    val ims by NodeProperty<IMS>()
 
     @NodeRelationship(PARTIALLY_SYNCED_ISSUES, Direction.OUTGOING)
     @GraphQLDescription("Issues which are currently partially synced with this IMSProject")

--- a/src/main/kotlin/gropius/model/architecture/Interface.kt
+++ b/src/main/kotlin/gropius/model/architecture/Interface.kt
@@ -25,11 +25,11 @@ class Interface(name: String, description: String) : RelationPartner(name, descr
     @GraphQLDescription("The ComponentVersion this Interface is part of.")
     @FilterProperty
     @delegate:Transient
-    var component by NodeProperty<ComponentVersion>()
+    val component by NodeProperty<ComponentVersion>()
 
     @NodeRelationship(SPECIFICATION, Direction.OUTGOING)
     @GraphQLDescription("The InterfaceSpecification which specifies this Interface and thereby defines its semantics.")
     @FilterProperty
     @delegate:Transient
-    var specification by NodeProperty<InterfaceSpecificationVersion>()
+    val specification by NodeProperty<InterfaceSpecificationVersion>()
 }

--- a/src/main/kotlin/gropius/model/architecture/InterfacePart.kt
+++ b/src/main/kotlin/gropius/model/architecture/InterfacePart.kt
@@ -44,6 +44,6 @@ class InterfacePart(name: String, description: String) : ServiceEffectSpecificat
     @GraphQLDescription("InterfaceSpecification which defines this InterfacePart")
     @FilterProperty
     @delegate:Transient
-    var definedOn by NodeProperty<InterfaceSpecification>()
+    val definedOn by NodeProperty<InterfaceSpecification>()
 
 }

--- a/src/main/kotlin/gropius/model/architecture/InterfaceSpecification.kt
+++ b/src/main/kotlin/gropius/model/architecture/InterfaceSpecification.kt
@@ -44,5 +44,5 @@ class InterfaceSpecification(name: String, description: String) : ServiceEffectS
     @GraphQLDescription("The Component this InterfaceSpecificaton is part of.")
     @FilterProperty
     @delegate:Transient
-    var component by NodeProperty<Component>()
+    val component by NodeProperty<Component>()
 }

--- a/src/main/kotlin/gropius/model/architecture/InterfaceSpecificationVersion.kt
+++ b/src/main/kotlin/gropius/model/architecture/InterfaceSpecificationVersion.kt
@@ -42,7 +42,7 @@ class InterfaceSpecificationVersion(
     @GraphQLDescription("The InterfaceSpecification this is part of.")
     @FilterProperty
     @delegate:Transient
-    var interfaceSpecification by NodeProperty<InterfaceSpecification>()
+    val interfaceSpecification by NodeProperty<InterfaceSpecification>()
 
     @NodeRelationship(Interface.SPECIFICATION, Direction.INCOMING)
     @GraphQLDescription("Interfaces this InterfaceSpecificationVersion defines.")

--- a/src/main/kotlin/gropius/model/architecture/Relation.kt
+++ b/src/main/kotlin/gropius/model/architecture/Relation.kt
@@ -28,13 +28,13 @@ class Relation : ExtensibleNode() {
     @GraphQLDescription("The end of this Relation.")
     @FilterProperty
     @delegate:Transient
-    var end by NodeProperty<RelationPartner>()
+    val end by NodeProperty<RelationPartner>()
 
     @NodeRelationship(RelationPartner.OUTGOING_RELATION, Direction.INCOMING)
     @GraphQLDescription("The start of this Relation.")
     @FilterProperty
     @delegate:Transient
-    var start by NodeProperty<RelationPartner>()
+    val start by NodeProperty<RelationPartner>()
 
     @NodeRelationship(START_PART, Direction.OUTGOING)
     @GraphQLDescription("If the start is an Interface, the parts of that Interface this Relation includes.")

--- a/src/main/kotlin/gropius/model/common/AuditedNode.kt
+++ b/src/main/kotlin/gropius/model/common/AuditedNode.kt
@@ -40,12 +40,12 @@ abstract class AuditedNode(
     @GraphQLDescription("The User who created this entity.")
     @FilterProperty
     @delegate:Transient
-    var createdBy by NodeProperty<User>()
+    val createdBy by NodeProperty<User>()
 
     @NodeRelationship(LAST_MODIFIED_BY, Direction.OUTGOING)
     @GraphQLDescription("The User who last modified this entity.")
     @FilterProperty
     @delegate:Transient
-    var lastModifiedBy by NodeProperty<User>()
+    val lastModifiedBy by NodeProperty<User>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/Artefact.kt
+++ b/src/main/kotlin/gropius/model/issue/Artefact.kt
@@ -43,7 +43,7 @@ class Artefact(
     @GraphQLDescription("The Trackable this Artefact is part of.")
     @FilterProperty
     @delegate:Transient
-    var trackable by NodeProperty<Trackable>()
+    val trackable by NodeProperty<Trackable>()
 
     @NodeRelationship(Issue.ARTEFACT, Direction.INCOMING)
     @GraphQLDescription("Issues which currently have this Artefact.")

--- a/src/main/kotlin/gropius/model/issue/Issue.kt
+++ b/src/main/kotlin/gropius/model/issue/Issue.kt
@@ -98,19 +98,19 @@ class Issue(
     @GraphQLDescription("The Body of the Issue, a Comment directly associated with the Issue.")
     @FilterProperty
     @delegate:Transient
-    var body by NodeProperty<Body>()
+    val body by NodeProperty<Body>()
 
     @NodeRelationship(TYPE, Direction.OUTGOING)
     @GraphQLDescription("The type of the Issue, e.g. BUG. Allowed IssueTypes are defined by the template.")
     @FilterProperty
     @delegate:Transient
-    var type by NodeProperty<IssueType>()
+    val type by NodeProperty<IssueType>()
 
     @NodeRelationship(PRIORITY, Direction.OUTGOING)
     @GraphQLDescription("The priority of the Issue, e.g. HIGH. Allowed IssuePriorities are defined by the template.")
     @FilterProperty
     @delegate:Transient
-    var priority by NodeProperty<IssuePriority?>()
+    val priority by NodeProperty<IssuePriority?>()
 
     @NodeRelationship(LABEL, Direction.OUTGOING)
     @GraphQLDescription("Labels currently assigned to the Issue. For the history, see timelineItems.")

--- a/src/main/kotlin/gropius/model/issue/timeline/AddedAffectedEntityEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/AddedAffectedEntityEvent.kt
@@ -23,6 +23,6 @@ class AddedAffectedEntityEvent(
     @GraphQLDescription("The entity affected by the Issue.")
     @FilterProperty
     @delegate:Transient
-    var addedAffectedEntity by NodeProperty<AffectedByIssue>()
+    val addedAffectedEntity by NodeProperty<AffectedByIssue>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/AddedArtefactEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/AddedArtefactEvent.kt
@@ -23,6 +23,6 @@ class AddedArtefactEvent(
     @GraphQLDescription("The Artefact added to the Issue.")
     @FilterProperty
     @delegate:Transient
-    var addedArtefact by NodeProperty<Artefact>()
+    val addedArtefact by NodeProperty<Artefact>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/AddedLabelEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/AddedLabelEvent.kt
@@ -23,6 +23,6 @@ class AddedLabelEvent(
     @GraphQLDescription("The Label added to the Issue.")
     @FilterProperty
     @delegate:Transient
-    var addedLabel by NodeProperty<Label>()
+    val addedLabel by NodeProperty<Label>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/AddedToPinnedIssuesEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/AddedToPinnedIssuesEvent.kt
@@ -23,6 +23,6 @@ class AddedToPinnedIssuesEvent(
     @GraphQLDescription("The Trackable the Issue is now pinned on.")
     @FilterProperty
     @delegate:Transient
-    var pinnedOn by NodeProperty<Trackable>()
+    val pinnedOn by NodeProperty<Trackable>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/AddedToTrackableEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/AddedToTrackableEvent.kt
@@ -23,6 +23,6 @@ class AddedToTrackableEvent(
     @GraphQLDescription("The Trackable the Issue was added to.")
     @FilterProperty
     @delegate:Transient
-    var addedToTrackable by NodeProperty<Trackable>()
+    val addedToTrackable by NodeProperty<Trackable>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/Assignment.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/Assignment.kt
@@ -27,12 +27,12 @@ class Assignment(createdAt: OffsetDateTime, lastModifiedAt: OffsetDateTime) : Ti
     @GraphQLDescription("The type of Assignment, e.g. REVIEWER. Allowed types are defined by the IssueTemplate.")
     @FilterProperty
     @delegate:Transient
-    var type by NodeProperty<AssignmentType?>()
+    val type by NodeProperty<AssignmentType?>()
 
     @NodeRelationship(USER, Direction.OUTGOING)
     @GraphQLDescription("The User assigned to the Issue.")
     @FilterProperty
     @delegate:Transient
-    var user by NodeProperty<User>()
+    val user by NodeProperty<User>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/Comment.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/Comment.kt
@@ -53,6 +53,6 @@ abstract class Comment(
     )
     @FilterProperty
     @delegate:Transient
-    var bodyLastEditedBy by NodeProperty<User>()
+    val bodyLastEditedBy by NodeProperty<User>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/IssueComment.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/IssueComment.kt
@@ -58,7 +58,7 @@ class IssueComment(
     @GraphQLDescription("The Comment this IssueComment is an answers to.")
     @FilterProperty
     @delegate:Transient
-    var answers by NodeProperty<Comment>()
+    val answers by NodeProperty<Comment>()
 
     @NodeRelationship(REFERENCED_ARTEFACT, Direction.OUTGOING)
     @GraphQLDescription("Referenced Artefacts. Changes to not cause lastEditedAt/lastEditedBy to change.")

--- a/src/main/kotlin/gropius/model/issue/timeline/IssueRelation.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/IssueRelation.kt
@@ -32,12 +32,12 @@ class IssueRelation(
     @GraphQLDescription("The type of the relation, e.g. DUPLICATES. Allowed types are defined by the IssueTemplate.")
     @FilterProperty
     @delegate:Transient
-    var type by NodeProperty<IssueRelationType?>()
+    val type by NodeProperty<IssueRelationType?>()
 
     @NodeRelationship(RELATED_ISSUE, Direction.OUTGOING)
     @GraphQLDescription("The end of the relation.")
     @FilterProperty
     @delegate:Transient
-    var relatedIssue by NodeProperty<Issue>()
+    val relatedIssue by NodeProperty<Issue>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/PriorityChangedEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/PriorityChangedEvent.kt
@@ -25,11 +25,11 @@ class PriorityChangedEvent(
     @GraphQLDescription("The old priority.")
     @FilterProperty
     @delegate:Transient
-    var oldPriority by NodeProperty<IssuePriority?>()
+    val oldPriority by NodeProperty<IssuePriority?>()
 
     @NodeRelationship(NEW_PRIORITY, Direction.OUTGOING)
     @GraphQLDescription("The new priority.")
     @FilterProperty
     @delegate:Transient
-    var newPriority by NodeProperty<IssuePriority?>()
+    val newPriority by NodeProperty<IssuePriority?>()
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RelatedByIssueEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RelatedByIssueEvent.kt
@@ -27,6 +27,6 @@ class RelatedByIssueEvent(
     @GraphQLDescription("The IssueRelation the Issue is related at.")
     @FilterProperty
     @delegate:Transient
-    var relation by NodeProperty<IssueRelation>()
+    val relation by NodeProperty<IssueRelation>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedAffectedEntityEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedAffectedEntityEvent.kt
@@ -23,6 +23,6 @@ class RemovedAffectedEntityEvent(
     @GraphQLDescription("The entity which is no longer affected by the Issue.")
     @FilterProperty
     @delegate:Transient
-    var removedAffectedEntity by NodeProperty<AffectedByIssue>()
+    val removedAffectedEntity by NodeProperty<AffectedByIssue>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedArtefactEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedArtefactEvent.kt
@@ -23,6 +23,6 @@ class RemovedArtefactEvent(
     @GraphQLDescription("The Artefact which was removed from the Issue.")
     @FilterProperty
     @delegate:Transient
-    var removedArtefact by NodeProperty<Artefact>()
+    val removedArtefact by NodeProperty<Artefact>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedAssignmentEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedAssignmentEvent.kt
@@ -26,6 +26,6 @@ class RemovedAssignmentEvent(
     @GraphQLDescription("The removed Assignment.")
     @FilterProperty
     @delegate:Transient
-    var removedAssignment by NodeProperty<Assignment>()
+    val removedAssignment by NodeProperty<Assignment>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedFromPinnedIssuesEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedFromPinnedIssuesEvent.kt
@@ -23,6 +23,6 @@ class RemovedFromPinnedIssuesEvent(
     @GraphQLDescription("The Trackable the Issue is no longer pinned on.")
     @FilterProperty
     @delegate:Transient
-    var unpinnedOn by NodeProperty<Trackable>()
+    val unpinnedOn by NodeProperty<Trackable>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedFromTrackableEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedFromTrackableEvent.kt
@@ -23,6 +23,6 @@ class RemovedFromTrackableEvent(
     @GraphQLDescription("The Trackable the Issue was removed from.")
     @FilterProperty
     @delegate:Transient
-    var removedFromTrackable by NodeProperty<Trackable>()
+    val removedFromTrackable by NodeProperty<Trackable>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedIncomingRelationEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedIncomingRelationEvent.kt
@@ -23,6 +23,6 @@ class RemovedIncomingRelationEvent(
     @GraphQLDescription("The IssueRelation removed from `incomingRelations`.")
     @FilterProperty
     @delegate:Transient
-    var removedRelation by NodeProperty<IssueRelation>()
+    val removedRelation by NodeProperty<IssueRelation>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedLabelEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedLabelEvent.kt
@@ -23,6 +23,6 @@ class RemovedLabelEvent(
     @GraphQLDescription("The Label removed from the Issue.")
     @FilterProperty
     @delegate:Transient
-    var removedLabel by NodeProperty<Label>()
+    val removedLabel by NodeProperty<Label>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/RemovedOutgoingRelationEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/RemovedOutgoingRelationEvent.kt
@@ -23,6 +23,6 @@ class RemovedOutgoingRelationEvent(
     @GraphQLDescription("The IssueRelation removed from `outgoingRelations`.")
     @FilterProperty
     @delegate:Transient
-    var removedRelation by NodeProperty<IssueRelation>()
+    val removedRelation by NodeProperty<IssueRelation>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/TimelineItem.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/TimelineItem.kt
@@ -19,6 +19,6 @@ abstract class TimelineItem(createdAt: OffsetDateTime, lastModifiedAt: OffsetDat
     @GraphQLDescription("The Issue this TimelineItem is part of.")
     @FilterProperty
     @delegate:Transient
-    var issue by NodeProperty<Issue>()
+    val issue by NodeProperty<Issue>()
 
 }

--- a/src/main/kotlin/gropius/model/issue/timeline/TypeChangedEvent.kt
+++ b/src/main/kotlin/gropius/model/issue/timeline/TypeChangedEvent.kt
@@ -25,11 +25,11 @@ class TypeChangedEvent(
     @GraphQLDescription("The old type.")
     @FilterProperty
     @delegate:Transient
-    var oldType by NodeProperty<IssueType>()
+    val oldType by NodeProperty<IssueType>()
 
     @NodeRelationship(NEW_TYPE, Direction.OUTGOING)
     @GraphQLDescription("The new type.")
     @FilterProperty
     @delegate:Transient
-    var newType by NodeProperty<IssueType>()
+    val newType by NodeProperty<IssueType>()
 }

--- a/src/main/kotlin/gropius/model/template/InterfaceSpecificationInheritanceCondition.kt
+++ b/src/main/kotlin/gropius/model/template/InterfaceSpecificationInheritanceCondition.kt
@@ -45,7 +45,7 @@ class InterfaceSpecificationInheritanceCondition(
     @GraphQLDescription("The RelationCondition this is part of.")
     @FilterProperty
     @delegate:Transient
-    var partOf by NodeProperty<RelationCondition>()
+    val partOf by NodeProperty<RelationCondition>()
 
     @NodeRelationship(INHERITABLE_INTERFACE_SPECIFICATION, Direction.OUTGOING)
     @GraphQLDescription("Templates of InterfaceSpecifications which are inherited.")

--- a/src/main/kotlin/gropius/model/user/IMSUser.kt
+++ b/src/main/kotlin/gropius/model/user/IMSUser.kt
@@ -36,11 +36,11 @@ class IMSUser(
     @GraphQLDescription("The GropiusUser this IMSUser is linked to. An IMSUser might be linked to no GropiusUser.")
     @FilterProperty
     @delegate:Transient
-    var gropiusUser by NodeProperty<GropiusUser?>()
+    val gropiusUser by NodeProperty<GropiusUser?>()
 
     @NodeRelationship(IMS.USER, Direction.INCOMING)
     @GraphQLDescription("The IMS this user is part of.")
     @FilterProperty
     @delegate:Transient
-    var ims by NodeProperty<IMS>()
+    val ims by NodeProperty<IMS>()
 }


### PR DESCRIPTION
- upgrade to spring boot 2.7.0
- upgrade to graphglue 3.0.0
  - bugfides
  - reactive lazy loading
  - improved FilterProperty support
- remove unnecessary (and/or disfunctional in our case) gradle plugins
- change var delegated properties to val as now Property value is a delegate and not Node itself