### PR TITLE
Feature/inverse interface propagation

### DIFF
--- a/api-public/src/main/kotlin/gropius/schema/mutation/ArchitectureMutations.kt
+++ b/api-public/src/main/kotlin/gropius/schema/mutation/ArchitectureMutations.kt
@@ -307,8 +307,7 @@ class ArchitectureMutations(
     }
 
     @GraphQLDescription(
-        """Creates a new Relation, requires RELATE_FROM_COMPONENT on the Component associated with 
-        start AND RELATE_TO_COMPONENT on the Component associated with end.
+        """Creates a new Relation, requires RELATE_FROM_COMPONENT on the Component associated with start.
         """
     )
     @AutoPayloadType("The created Relation")
@@ -322,8 +321,7 @@ class ArchitectureMutations(
     }
 
     @GraphQLDescription(
-        """Updates the specified Relation, requires RELATE_FROM_COMPONENT on the Component associated with 
-        start AND RELATE_TO_COMPONENT on the Component associated with end.
+        """Updates the specified Relation, requires RELATE_FROM_COMPONENT on the Component associated with start.
         """
     )
     @AutoPayloadType("The updated Relation")
@@ -337,8 +335,7 @@ class ArchitectureMutations(
     }
 
     @GraphQLDescription(
-        """Deletes the specified Relation, requires RELATE_FROM_COMPONENT on the Component associated with 
-        start OR RELATE_TO_COMPONENT on the Component associated with end.
+        """Deletes the specified Relation, requires RELATE_FROM_COMPONENT on the Component associated with start.
         """
     )
     @AutoPayloadType("The id of the deleted Relation")

--- a/core/src/main/kotlin/gropius/model/architecture/Component.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/Component.kt
@@ -1,7 +1,6 @@
 package gropius.model.architecture
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
-import gropius.authorization.RELATED_TO_NODE_PERMISSION_RULE
 import gropius.model.user.permission.COMPONENT_PERMISSION_ENTRY_NAME
 import gropius.model.user.permission.ComponentPermission
 import gropius.model.user.permission.NodePermission
@@ -27,10 +26,6 @@ import java.net.URI
     """
 )
 @Authorization(NodePermission.READ, allowFromRelated = ["versions"])
-@Authorization(
-    ComponentPermission.RELATE_TO_COMPONENT,
-    allow = [Rule(COMPONENT_PERMISSION_ENTRY_NAME, options = [NodePermission.ADMIN])]
-)
 @Authorization(
     ComponentPermission.RELATE_FROM_COMPONENT,
     allow = [Rule(COMPONENT_PERMISSION_ENTRY_NAME, options = [NodePermission.ADMIN])]

--- a/core/src/main/kotlin/gropius/model/architecture/ComponentVersion.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/ComponentVersion.kt
@@ -20,7 +20,6 @@ import org.springframework.data.neo4j.core.schema.CompositeProperty
 )
 @Authorization(NodePermission.READ, allowFromRelated = ["component", "includingProjects"])
 @Authorization(NodePermission.ADMIN, allowFromRelated = ["component"])
-@Authorization(ComponentPermission.RELATE_TO_COMPONENT, allowFromRelated = ["component"])
 @Authorization(ComponentPermission.RELATE_FROM_COMPONENT, allowFromRelated = ["component"])
 @Authorization(ComponentPermission.ADD_TO_PROJECTS, allowFromRelated = ["component"])
 class ComponentVersion(

--- a/core/src/main/kotlin/gropius/model/architecture/Interface.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/Interface.kt
@@ -20,7 +20,6 @@ import org.springframework.data.neo4j.core.schema.CompositeProperty
 )
 @Authorization(NodePermission.READ, allowFromRelated = ["interfaceDefinition"])
 @Authorization(NodePermission.ADMIN, allowFromRelated = ["interfaceDefinition"])
-@Authorization(ComponentPermission.RELATE_TO_COMPONENT, allowFromRelated = ["interfaceDefinition"])
 @Authorization(ComponentPermission.RELATE_FROM_COMPONENT, allowFromRelated = ["interfaceDefinition"])
 class Interface(
     name: String,

--- a/core/src/main/kotlin/gropius/model/architecture/InterfaceDefinition.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/InterfaceDefinition.kt
@@ -22,7 +22,6 @@ import org.springframework.data.neo4j.core.schema.CompositeProperty
 )
 @Authorization(NodePermission.READ, allowFromRelated = ["componentVersion"])
 @Authorization(NodePermission.ADMIN, allowFromRelated = ["componentVersion"])
-@Authorization(ComponentPermission.RELATE_TO_COMPONENT, allowFromRelated = ["componentVersion"])
 @Authorization(ComponentPermission.RELATE_FROM_COMPONENT, allowFromRelated = ["componentVersion"])
 class InterfaceDefinition(
     @property:GraphQLDescription(

--- a/core/src/main/kotlin/gropius/model/architecture/Relation.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/Relation.kt
@@ -15,13 +15,15 @@ import org.springframework.data.neo4j.core.schema.CompositeProperty
 @GraphQLDescription(
     """A relation between RelationPartners (ComponentVersions and Interfaces).
     Relations are always directional.
-    The template defines which RelationPartners are possible as start / end.
+    Relations can derive Interfaces from `end` to `start` if both `start` and `end` are ComponentVersions
+    and the template of this Relation allows it.
+    The template defines which RelationPartners are possible as `start` / `end`.
     For both start and end, if it is an Interface, it is possible to define the InterfaceParts this includes.
     Caution: This is **not** a supertype of IssueRelation.
-    READ is granted if READ is granted on `start` or `end`.
+    READ is granted if READ is granted on `start`.
     """
 )
-@Authorization(NodePermission.READ, allowFromRelated = ["start", "end"])
+@Authorization(NodePermission.READ, allowFromRelated = ["start"])
 class Relation(
     @property:GraphQLIgnore
     @CompositeProperty

--- a/core/src/main/kotlin/gropius/model/user/permission/ComponentPermission.kt
+++ b/core/src/main/kotlin/gropius/model/user/permission/ComponentPermission.kt
@@ -20,11 +20,6 @@ class ComponentPermission(
 ) : TrackablePermission<Component>(name, description, entries, allUsers) {
 
     companion object {
-        /**
-         * Permission to check if a user can create [Relation]s with a version of the [Component]
-         * or an [Interface] of the [Component] as end
-         */
-        const val RELATE_TO_COMPONENT = "RELATE_TO_COMPONENT"
 
         /**
          * Permission to check if a user can create [Relation]s with a version of the [Component]

--- a/core/src/main/kotlin/gropius/model/user/permission/PermissionConfiguration.kt
+++ b/core/src/main/kotlin/gropius/model/user/permission/PermissionConfiguration.kt
@@ -148,13 +148,6 @@ class PermissionConfiguration {
     fun componentPermissionEntries() = PermissionEntryCollection<ComponentPermission>(
         trackablePermissionEntries + setOf(
             PermissionEntry(
-                ComponentPermission.RELATE_TO_COMPONENT, """
-                    Allows to create Relations with a version of this Component or an Interface of this Component
-                    as end.
-                    Note: this should be handled carefully, as such Relations can result in new Interfaces
-                    on the ComponentVersion.
-                """.trimIndent()
-            ), PermissionEntry(
                 ComponentPermission.RELATE_FROM_COMPONENT, """
                     Allows to create Relations with a version of this Component or an Interface of this Component
                     as start.

--- a/core/src/main/kotlin/gropius/service/architecture/RelationService.kt
+++ b/core/src/main/kotlin/gropius/service/architecture/RelationService.kt
@@ -89,7 +89,7 @@ class RelationService(
         start: RelationPartner,
         end: RelationPartner,
         authorizationContext: GropiusAuthorizationContext
-        ) {
+    ) {
         checkPermission(
             start,
             Permission(ComponentPermission.RELATE_FROM_COMPONENT, authorizationContext),
@@ -97,7 +97,7 @@ class RelationService(
         )
         checkPermission(
             end,
-            Permission(ComponentPermission.RELATE_TO_COMPONENT, authorizationContext),
+            Permission(NodePermission.READ, authorizationContext),
             "use the specified end in Relations"
         )
     }
@@ -208,14 +208,11 @@ class RelationService(
     ) {
         input.validate()
         val relation = repository.findById(input.id)
-        if (!evaluatePermission(
-                relation.start().value, Permission(ComponentPermission.RELATE_FROM_COMPONENT, authorizationContext)
-            ) && !evaluatePermission(
-                relation.end().value, Permission(ComponentPermission.RELATE_TO_COMPONENT, authorizationContext)
-            )
-        ) {
-            throw IllegalArgumentException("User does not have permission to delete the Relation")
-        }
+        checkPermission(
+            relation.start().value,
+            Permission(ComponentPermission.RELATE_FROM_COMPONENT, authorizationContext),
+            "delete the Relation"
+        )
         val graphUpdater = ComponentGraphUpdater()
         graphUpdater.deleteRelation(relation)
         nodeRepository.deleteAll(graphUpdater.deletedNodes).awaitSingleOrNull()

--- a/core/src/main/kotlin/gropius/service/architecture/RelationService.kt
+++ b/core/src/main/kotlin/gropius/service/architecture/RelationService.kt
@@ -163,7 +163,11 @@ class RelationService(
     ): Relation {
         input.validate()
         val relation = repository.findById(input.id)
-        checkRelationAuthorization(relation.start().value, relation.end().value, authorizationContext)
+        checkPermission(
+            relation.start().value,
+            Permission(ComponentPermission.RELATE_FROM_COMPONENT, authorizationContext),
+            "update the Relation"
+        )
         val nodesToSave = mutableSetOf<Node>(relation)
         nodesToSave += updateRelationTemplate(input, relation)
         input.addedStartParts.ifPresent { relation.startParts() += getInterfaceParts(relation.start().value, it) }


### PR DESCRIPTION
- inverses the Interface propagation (now from end to start)
- changes the Permission model of Relations
  - to create, RELATE_FROM_COMPONENT is required on the start and READ on the end
  - to update, only RELATE_FROM_COMPONENT on the start of the Relation is required
  - to delete, only RELATE_FROM_COMPONENT on the start of the Relation is required
  - READ is granted on a Relation if READ is granted on its start