### PR TITLE
dependency upgrade and other fixes

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: '42 14 * * 3' # every thursday at 2:42 pm
 
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'

--- a/api-common/src/main/kotlin/gropius/graphql/DurationScalar.kt
+++ b/api-common/src/main/kotlin/gropius/graphql/DurationScalar.kt
@@ -1,23 +1,27 @@
 package gropius.graphql
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.*
 import java.time.Duration
 import java.time.OffsetDateTime
 import java.time.format.DateTimeParseException
+import java.util.*
 
 /**
  * Coercing for [DurationScalar]
  */
 private val DurationCoercing = object : Coercing<Duration, String> {
-    override fun serialize(input: Any): String {
+    override fun serialize(input: Any, graphQLContext: GraphQLContext, locale: Locale): String {
         if (input !is OffsetDateTime) {
             throw CoercingSerializeException("Expected Duration")
         }
         return input.toString()
     }
 
-    override fun parseValue(input: Any): Duration {
+    override fun parseValue(input: Any, graphQLContext: GraphQLContext, locale: Locale): Duration {
         return when(input) {
             is String -> {
                 try {
@@ -31,7 +35,12 @@ private val DurationCoercing = object : Coercing<Duration, String> {
         }
     }
 
-    override fun parseLiteral(input: Any): Duration {
+    override fun parseLiteral(
+        input: Value<*>,
+        variables: CoercedVariables,
+        graphQLContext: GraphQLContext,
+        locale: Locale
+    ): Duration {
         if (input !is StringValue) {
             throw CoercingParseLiteralException("Expected AST type 'StringValue'")
         }

--- a/api-common/src/main/kotlin/gropius/graphql/JSONCoercing.kt
+++ b/api-common/src/main/kotlin/gropius/graphql/JSONCoercing.kt
@@ -3,9 +3,15 @@ package gropius.graphql
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.*
 import graphql.scalars.`object`.ObjectScalar
-import graphql.schema.*
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import java.util.*
 
 /**
  * GraphQL Coercing which maps JSON objects from / to [JsonNode]
@@ -14,14 +20,14 @@ import graphql.schema.*
  */
 class JSONCoercing(private val objectMapper: ObjectMapper) : Coercing<JsonNode, JsonNode> {
 
-    override fun serialize(dataFetcherResult: Any): JsonNode {
+    override fun serialize(dataFetcherResult: Any, graphQLContext: GraphQLContext, locale: Locale): JsonNode {
         if (dataFetcherResult !is JsonNode) {
             throw CoercingSerializeException("Only JSONNodes can be serialized")
         }
         return dataFetcherResult
     }
 
-    override fun parseValue(input: Any): JsonNode {
+    override fun parseValue(input: Any, graphQLContext: GraphQLContext, locale: Locale): JsonNode {
         try {
             return objectMapper.valueToTree(input)
         } catch (e: Exception) {
@@ -29,11 +35,12 @@ class JSONCoercing(private val objectMapper: ObjectMapper) : Coercing<JsonNode, 
         }
     }
 
-    override fun parseLiteral(input: Any): JsonNode {
-        return parseLiteral(input, emptyMap())
-    }
-
-    override fun parseLiteral(input: Any, variables: Map<String, Any>): JsonNode {
+    override fun parseLiteral(
+        input: Value<*>,
+        variables: CoercedVariables,
+        graphQLContext: GraphQLContext,
+        locale: Locale
+    ): JsonNode {
         return when (input) {
             is NullValue -> JsonNodeFactory.instance.nullNode()
             is FloatValue -> JsonNodeFactory.instance.numberNode(input.value)
@@ -41,20 +48,26 @@ class JSONCoercing(private val objectMapper: ObjectMapper) : Coercing<JsonNode, 
             is IntValue -> JsonNodeFactory.instance.numberNode(input.value)
             is BooleanValue -> JsonNodeFactory.instance.booleanNode(input.isValue)
             is EnumValue -> JsonNodeFactory.instance.textNode(input.name)
-            is VariableReference -> parseValue(variables[input.name] ?: input.name)
+            is VariableReference -> parseValue(variables[input.name] ?: input.name, graphQLContext, locale)
             is ArrayValue -> JsonNodeFactory.instance.arrayNode().also { arrayNode ->
-                arrayNode.addAll(input.values.map { parseLiteral(it, variables) })
+                arrayNode.addAll(input.values.map { parseLiteral(it, variables, graphQLContext, locale) })
             }
+
             is ObjectValue -> JsonNodeFactory.instance.objectNode().also { objectNode ->
                 objectNode.setAll<JsonNode>(input.objectFields.associate {
-                    it.name to parseLiteral(it.value, variables)
+                    it.name to if (it.value is NullValue) {
+                        JsonNodeFactory.instance.nullNode()
+                    } else {
+                        parseLiteral(it.value, variables, graphQLContext, locale)
+                    }
                 })
             }
+
             else -> throw CoercingParseLiteralException("Cannot handle literal $input")
         }
     }
 
-    override fun valueToLiteral(input: Any): Value<out Value<*>> {
-        return ObjectScalar.INSTANCE.coercing.valueToLiteral(input)
+    override fun valueToLiteral(input: Any, graphQLContext: GraphQLContext, locale: Locale): Value<out Value<*>> {
+        return ObjectScalar.INSTANCE.coercing.valueToLiteral(input, graphQLContext, locale)
     }
 }

--- a/api-common/src/main/kotlin/gropius/graphql/URLScalar.kt
+++ b/api-common/src/main/kotlin/gropius/graphql/URLScalar.kt
@@ -1,16 +1,20 @@
 package gropius.graphql
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.*
 import java.net.URI
 import java.net.URISyntaxException
+import java.util.*
 
 /**
  * Coercing for the [URLScalar]
  */
 private val URLCoercing = object : Coercing<URI, String> {
 
-    override fun serialize(input: Any): String {
+    override fun serialize(input: Any, graphQLContext: GraphQLContext, locale: Locale): String {
         if (input !is URI) {
             throw CoercingSerializeException("Expected URI")
         }
@@ -20,7 +24,7 @@ private val URLCoercing = object : Coercing<URI, String> {
         return input.toString()
     }
 
-    override fun parseValue(input: Any): URI {
+    override fun parseValue(input: Any, graphQLContext: GraphQLContext, locale: Locale): URI {
         val uri = when (input) {
             is String -> {
                 try {
@@ -29,6 +33,7 @@ private val URLCoercing = object : Coercing<URI, String> {
                     throw CoercingParseValueException(e)
                 }
             }
+
             is URI -> input
             else -> throw CoercingParseValueException("unsupported type")
         }
@@ -38,7 +43,12 @@ private val URLCoercing = object : Coercing<URI, String> {
         return uri
     }
 
-    override fun parseLiteral(input: Any): URI {
+    override fun parseLiteral(
+        input: Value<*>,
+        variables: CoercedVariables,
+        graphQLContext: GraphQLContext,
+        locale: Locale
+    ): URI {
         if (input !is StringValue) {
             throw CoercingParseLiteralException("Expected AST type 'StringValue'")
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
     tasks.withType<KotlinCompile> {
         kotlinOptions.jvmTarget = javaVersion

--- a/github/src/main/kotlin/gropius/sync/github/NodeSourcerer.kt
+++ b/github/src/main/kotlin/gropius/sync/github/NodeSourcerer.kt
@@ -63,7 +63,7 @@ class NodeSourcerer(
             }
         }
         var template = IssueTemplate("github-temp", "Github Template", mutableMapOf(), false)
-        template.issueTypes() += IssueType("github-issue", "Issue synced from GitHub")
+        template.issueTypes() += IssueType("github-issue", "Issue synced from GitHub", "M 0 0 L 100 100")
         template.issueStates() += listOf(
             IssueState("Open", "State hinting the Issue is open", true),
             IssueState("Closed", "State hinting the Issue is closed", false)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ javaVersion = 17
 
 # dependencies
 springBootVersion = 3.1.1
-graphglueVersion = 5.0.2
+graphglueVersion = 5.0.3
 graphqlJavaVersion = 20.2
 apolloVersion = 3.8.2
 kosonVersion = 1.2.8


### PR DESCRIPTION
- upgrades graphglue
- removes schedule from action which causes workflow to be deactivated
- change scalar overwrites due to deprecations
- remove sonatype snapshot repository