### PR TITLE
add webflux to sync

### DIFF
--- a/sync/build.gradle.kts
+++ b/sync/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     api("org.jetbrains.kotlinx", "kotlinx-serialization-json", kotlinxSerializationVersion)
     api("io.ktor", "ktor-serialization-kotlinx-json", ktorVersion)
     api("org.springframework.boot", "spring-boot-starter-data-mongodb-reactive", springBootVersion)
+    implementation("org.springframework.boot", "spring-boot-starter-webflux", springBootVersion)
 }


### PR DESCRIPTION
Turns out spring actuator does not come with a webserver by default