### PR TITLE
mark entity of relation data as nullable, remove no longer needed layout data when necessary

### DIFF
--- a/core/src/main/kotlin/gropius/model/architecture/layout/RelationLayout.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/layout/RelationLayout.kt
@@ -23,6 +23,7 @@ class RelationLayout(
 
     @NodeRelationship(Relation.LAYOUT, Direction.INCOMING)
     @GraphQLDescription("The Relation this layout is for.")
+    @GraphQLNullable
     @FilterProperty
     val relation by NodeProperty<Relation>()
 

--- a/core/src/main/kotlin/gropius/model/architecture/layout/RelationPartnerLayout.kt
+++ b/core/src/main/kotlin/gropius/model/architecture/layout/RelationPartnerLayout.kt
@@ -23,6 +23,7 @@ class RelationPartnerLayout(
 
     @NodeRelationship(RelationPartner.LAYOUT, Direction.INCOMING)
     @GraphQLDescription("The RelationPartner this layout is for.")
+    @GraphQLNullable
     @FilterProperty
     val relationPartner by NodeProperty<RelationPartner>()
 

--- a/core/src/main/kotlin/gropius/service/architecture/ProjectService.kt
+++ b/core/src/main/kotlin/gropius/service/architecture/ProjectService.kt
@@ -192,7 +192,7 @@ class ProjectService(
                 }
             }
         }
-        nodeRepository.deleteAll(toDelete)
+        nodeRepository.deleteAll(toDelete).awaitSingleOrNull()
         return repository.save(project).awaitSingle()
     }
 


### PR DESCRIPTION
- currently, removing component versions from a project does not delete the layout data
- as this can affect the visibility of the component version / relations, the layout may no longer return this data
- fixes
  - mark these datas as nullable for the API
  - delete this data when possible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - The relation and relation partner fields in layout-related GraphQL schemas can now be optionally null when queried or mutated.

- **Bug Fixes**
    - Improved cleanup when removing a component version from a project to ensure related layout elements are also properly deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->